### PR TITLE
Tutorial claims docker-compose will show aggregated logs but it doesn't

### DIFF
--- a/_posts/2018-04-04-kubernetes-workshop.markdown
+++ b/_posts/2018-04-04-kubernetes-workshop.markdown
@@ -154,7 +154,7 @@ there is a Compose file `docker-compose.yml` ...
 * Use Compose to build and run all containers:
 
   ```.term1
-  docker-compose up -d
+  docker-compose up
   ```
 
 Compose tells Docker to build all container images (pulling the corresponding base images), then starts all containers, and displays aggregated logs.


### PR DESCRIPTION
In the tutorial, the user is asked to run `docker-compose up -d`.

-----------------------------------------------
### Running the application

* Go to the dockercoins directory, in the cloned repo:

  ```.term1
  cd ~/dockercoins
  ```

* Use Compose to build and run all containers:

  ```.term1
  docker-compose up -d
  ```

Compose tells Docker to build all container images (pulling the corresponding base images), then starts all containers, and displays aggregated logs.

### Lots of logs

* The application continuously generates logs

* We can see the worker service making requests to rng and hasher

*  Let's put that in the background
-----------------------------------------------
However, because the command mentioned, `docker-compose up -d` actually puts Docker Compose into "detached mode", the logs are actually not displayed at all.
```
[node1 dockercoins]$ docker-compose up -d
Creating network "dockercoins_default" with the default driver
Creating dockercoins_hasher_1 ... done
Creating dockercoins_webui_1  ... done
Creating dockercoins_rng_1    ... done
Creating dockercoins_worker_1 ... done
Creating dockercoins_redis_1  ... done
[node1 dockercoins]$
```
The tutorial should not mention the `-d` flag so that the user can see all of the logs being dumped out on the command line.