### PR TITLE
Fix message typo

### DIFF
--- a/_posts/2018-04-04-kubernetes-workshop.markdown
+++ b/_posts/2018-04-04-kubernetes-workshop.markdown
@@ -35,7 +35,7 @@ That will take a couple of minutes, during which time you'll see a lot of activi
 
 You will see something like this at the end:
 
-our Kubernetes master has initialized successfully!
+Your Kubernetes master has initialized successfully!
 
 To start using your cluster, you need to run (as a regular user):
 


### PR DESCRIPTION
It should be:
`Your Kubernetes master has initialized successfully!`
instead of:
`oour Kubernetes master has initialized successfully!`