### PR TITLE
fix little typo

### DIFF
--- a/_posts/2018-04-04-kubernetes-workshop.markdown
+++ b/_posts/2018-04-04-kubernetes-workshop.markdown
@@ -721,7 +721,7 @@ and create them on the cluster with `kubectl apply -f` (discussed later)
 
 * A selector is a logic expression using *labels*
 
-* Conveniently, when `you kubectl run somename`, the associated objects have a `run=somename` label
+* Conveniently, when you `kubectl run somename`, the associated objects have a `run=somename` label
 
 * View the last line of log from all pods with the `run=pingpong` label:
 


### PR DESCRIPTION
In _Viewing logs of multiple pods_ section, `you` shouldn't be highlighted as it is not intended to be part of the command