### PR TITLE
Fix typo to list all available resource types

### DIFF
--- a/_posts/2018-04-04-kubernetes-workshop.markdown
+++ b/_posts/2018-04-04-kubernetes-workshop.markdown
@@ -448,7 +448,7 @@ Before moving on, let's turn everything off by typing `Ctrl-C`.
 
 * `kubectl` has pretty good introspection facilities
 
-* We can list all available resource types by running `kubectl get`
+* We can list all available resource types by running `kubectl api-resources`
 
 * We can view details about a resource with:
   ```

--- a/_posts/2018-04-04-kubernetes-workshop.markdown
+++ b/_posts/2018-04-04-kubernetes-workshop.markdown
@@ -780,7 +780,7 @@ Under the hood: `kube-proxy` is using a userland proxy and a bunch of `iptables`
 * `ExternalName`
 
   * the DNS entry managed by `kube-dns` will just be a `CNAME` to a provided record
-  * no port, no IP address, no nothing else is allocated
+  * no port, no IP address, nothing else is allocated
 
 ### Running containers with open ports
 


### PR DESCRIPTION
Like mentioned by the `kubectl` command output, we should use `api-resources` instead of `get`

> $ kubectl get
> You must specify the type of resource to get. Use "kubectl api-resources" for a complete list of supported resources.
> 
> error: Required resource not specified.
> Use "kubectl explain <resource>" for a detailed description of that resource (e.g. kubectl explain pods).
> See 'kubectl get -h' for help and examples.