### PR TITLE
Fixes #55 - Change URL of pwd.js to working CDN

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,4 +28,5 @@
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet">
 <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">  
 <link rel="stylesheet" href="{{site.baseurl}}/css/quiz.css">
+<link rel="stylesheet" href="https://unpkg.com/pwd-sdk@0.0.12/dist/styles.css" />
 </head>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -79,6 +79,7 @@ layout: default
           console.log('In _config.yml, the site url does not match the url you are serving from, so no analytics were pushed.')
       }
     {% endif %}
+    pwd = new PWD();
     pwd.newSession([{selector: '.term1'}, {selector: '.term2'}, {selector: '.term3'}], {baseUrl: '{{site.pwkurl}}', ImageName: '{{page.image}}'});
     $(".panel-left").resizable({
         handleSelector: ".splitter",

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -59,7 +59,7 @@ layout: default
 </script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
 <script src="https://rawgit.com/RickStrahl/jquery-resizable/master/dist/jquery-resizable.min.js"></script>
-<script src="https://cdn.rawgit.com/play-with-docker/sdk/master/dist/pwd.js"></script>
+<script src="https://unpkg.com/pwd-sdk@0.0.12/dist/pwd.min.js"></script>
 <script src="{{site.baseurl}}/js/quiz.js"></script>
 <script>
     var siteUrl = "{{ site.url }}"


### PR DESCRIPTION
The playground is not loading properly because the CDN where {{pwd.js}} was hosted is no longer available (Issue #55). This PR fixes that by loading the script from a working CDN.  